### PR TITLE
Add EPEL for Amazon Linux 2 systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v1.4.0:
+
+* Set up the EPEL repo for Amazon Linux 2 systems
+
+## v1.3.1:
+
+* [COOK-2881] - Create the log directory for the Munin client
+
 ## v1.3.0:
 
 * [COOK-2518] - Multi Environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.4.1:
+
+* Add idempotency to EPEL installation
+
 ## v1.4.0:
 
 * Set up the EPEL repo for Amazon Linux 2 systems

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Installs and configures munin"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.4.0"
+version           "1.4.1"
 
 depends "apache2", ">= 1.0.6"
 depends "nginx"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Installs and configures munin"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.3.1"
+version           "1.4.0"
 
 depends "apache2", ">= 1.0.6"
 depends "nginx"

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -30,6 +30,7 @@ bash 'setup-epel-for-amazon-linux-2' do
     rpm -Uvh dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-*.rpm
   EOH
   only_if 'cat /etc/system-release | grep -q "^Amazon Linux release 2.0"'
+  not_if { ::File.exist?('/etc/yum.repos.d/epel.repo') }
 end
 
 package "munin-node"

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -23,6 +23,15 @@ else
   munin_servers = search(:node, "role:#{node['munin']['server_role']} AND chef_environment:#{node.chef_environment}")
 end
 
+bash 'setup-epel-for-amazon-linux-2' do
+  cwd '/tmp'
+  code <<-EOH
+    wget -r --no-parent -A 'epel-release-*.rpm' http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/
+    rpm -Uvh dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-*.rpm
+  EOH
+  only_if 'cat /etc/system-release | grep -q "^Amazon Linux release 2.0"'
+end
+
 package "munin-node"
 
 service_name = node['munin']['service_name']


### PR DESCRIPTION
Otherwise, this recipe fails, as `munin-node` is unavailable in the amzn2-core repositories.